### PR TITLE
Improve TCP flow diagram plugin

### DIFF
--- a/tcp_flow_diagram.lua
+++ b/tcp_flow_diagram.lua
@@ -1,0 +1,84 @@
+-- TCP Flow Diagram Wireshark Plugin
+-- Displays per-stream TCP packet flows in a simple text sequence diagram.
+
+if not gui_enabled() then
+    return
+end
+
+local tcp_stream_f   = Field.new("tcp.stream")
+local ip_src_f       = Field.new("ip.src")
+local ip_dst_f       = Field.new("ip.dst")
+local tcp_srcport_f  = Field.new("tcp.srcport")
+local tcp_dstport_f  = Field.new("tcp.dstport")
+local tcp_syn_f      = Field.new("tcp.flags.syn")
+local tcp_ack_f      = Field.new("tcp.flags.ack")
+local tcp_fin_f      = Field.new("tcp.flags.fin")
+local tcp_rst_f      = Field.new("tcp.flags.reset")
+local tcp_psh_f      = Field.new("tcp.flags.push")
+
+local streams = {}
+
+local function format_flags()
+    local flags = ""
+    if tcp_syn_f() and tcp_syn_f().value == 1 then flags = flags .. "S" end
+    if tcp_ack_f() and tcp_ack_f().value == 1 then flags = flags .. "A" end
+    if tcp_fin_f() and tcp_fin_f().value == 1 then flags = flags .. "F" end
+    if tcp_rst_f() and tcp_rst_f().value == 1 then flags = flags .. "R" end
+    if tcp_psh_f() and tcp_psh_f().value == 1 then flags = flags .. "P" end
+    if flags == "" then flags = "-" end
+    return flags
+end
+
+local function packet_listener()
+    local tap = Listener.new("tcp")
+
+    function tap.packet(pinfo, tvb)
+        local stream_field = tcp_stream_f()
+        if not stream_field then return end
+        local stream = tostring(stream_field)
+        local entry = {
+            time  = string.format("%.6f", pinfo.rel_ts),
+            src   = tostring(ip_src_f()),
+            dst   = tostring(ip_dst_f()),
+            sport = tostring(tcp_srcport_f()),
+            dport = tostring(tcp_dstport_f()),
+            len   = pinfo.len,
+            flags = format_flags()
+        }
+        if not streams[stream] then streams[stream] = {} end
+        table.insert(streams[stream], entry)
+    end
+
+    local win = TextWindow.new("TCP Flow Diagram")
+
+    local function draw()
+        win:clear()
+        for stream, items in pairs(streams) do
+            win:append(string.format("Stream %s\n", stream))
+            win:append(string.format("%-23s %-23s\n", "Source", "Destination"))
+            for _, e in ipairs(items) do
+                local left = string.format("%s:%s", e.src, e.sport)
+                local right = string.format("%s:%s", e.dst, e.dport)
+                win:append(string.format("%8s %-23s --> %-23s len %-5d [%s]\n",
+                    e.time, left, right, e.len, e.flags))
+            end
+            win:append("\n")
+        end
+    end
+
+    win:set_atclose(function() tap:remove() end)
+    win:add_button("Refresh", draw)
+
+    function tap.draw()
+        draw()
+    end
+
+    function tap.reset()
+        streams = {}
+        win:clear()
+    end
+
+    draw()
+end
+
+register_menu("TCP Flow Diagram", packet_listener, MENU_TOOLS_UNSORTED)


### PR DESCRIPTION
## Summary
- enhance `tcp_flow_diagram.lua` to produce a clearer per-stream TCP sequence diagram
- show TCP flag information for each packet
- add refresh button and close handler so the tap is removed when the window is closed

## Testing
- `lua -v` *(fails: command not found)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68760e488b548333a4f3deb1f4a82bee